### PR TITLE
LTSVIEWER-315 Upgrading packages to secure versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mirador-coverpages",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mirador-coverpages",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "axios": "^1.7.4",
         "cookie-parser": "~1.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador-coverpages",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",


### PR DESCRIPTION
**LTSVIEWER-315 Upgrading packages to secure versions.**

---

**JIRA Ticket**: [LTSVIEWER-315](https://at-harvard.atlassian.net/browse/LTSVIEWER-315)

# What does this Pull Request do?

This upgrades a bunch of node packages to resolve the urgent / high dependabot alerts. It includes:

-  @babel/traverse
- axios
- body-parser
- braces

# How should this be tested?

A description of what steps someone could take to:

- Reproduce the problem you are fixing (if applicable)
- Pull in the latest code from the `LTSVIEWER-315-security-patches` branch
- If you've worked locally on this plugin before, delete your local `node_modules` folder
- run `npm install`
- Run the following commands and confirm they complete successfully: `npm run test`
- You can also run npm list commands to confirm that versions for each package listed as urgent or high in the dependabot alerts are at a version higher than the affected version. For example `npm list rollup`


Tag (@ mention) interested parties
@f8f8ff @enriquediaz 

[LTSVIEWER-315]: https://at-harvard.atlassian.net/browse/LTSVIEWER-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ