### PR TITLE
LTSVIEWER-349 Upgrade Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mirador-coverpages",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mirador-coverpages",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "axios": "^1.11.0",
         "cookie-parser": "~1.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mirador-coverpages",
       "version": "0.0.2",
       "dependencies": {
-        "axios": "^1.7.4",
+        "axios": "^1.11.0",
         "cookie-parser": "~1.4.6",
         "date-fns": "^2.29.3",
         "debug": "~4.3.4",
@@ -1326,13 +1326,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2259,6 +2259,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2554,13 +2569,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirador-coverpages",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:integration": "./node_modules/.bin/jest --testPathPattern=__tests__/integration"
   },
   "dependencies": {
-    "axios": "^1.7.4",
+    "axios": "^1.11.0",
     "cookie-parser": "~1.4.6",
     "date-fns": "^2.29.3",
     "debug": "~4.3.4",


### PR DESCRIPTION
**LTSVIEWER-349 Upgrade Axios**

---

**JIRA Ticket**: [LTSVIEWER-349](https://at-harvard.atlassian.net/browse/LTSVIEWER-349)


# What does this Pull Request do?
This just upgrades Axios to 1.11.0. It patches a critical update in the form-data package.
# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest version of the code.
* Run `nvm use`
* Run `npm install`
* Run `npm list form-data` and confirm it is no longer installed.
* None of the other NPM commands work. This plugin is currently unused.

# Interested parties
@f8f8ff @enriquediaz 

[LTSVIEWER-349]: https://at-harvard.atlassian.net/browse/LTSVIEWER-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ